### PR TITLE
fix #33 cleans up the replicated db config code

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -64,33 +64,8 @@ $db['default'] = array(
   'cachedir' => ""
 );
 
-
-$db['eus_for_myemsl'] = array(
-  'hostname' => $myemsl_array['metadata']['host'],
-  'username' => $myemsl_array['metadata']['user'],
-  'password' => $myemsl_array['metadata']['password'],
-  'database' => $myemsl_array['metadata']['database'],
-  'dbdriver' => "postgre",
-  'dbprefix' => "eus.",
-  'pconnect' => TRUE,
-  'db_debug' => TRUE,
-  'cache_on' => FALSE,
-  'cachedir' => ""
-);
-
-
-$db['website_prefs'] = array(
-  'hostname' => $myemsl_array['metadata']['host'],
-  'username' => $myemsl_array['metadata']['user'],
-  'password' => $myemsl_array['metadata']['password'],
-  'database' => $myemsl_array['metadata']['database'],
-  'dbdriver' => "postgre",
-  'dbprefix' => "website_prefs.",
-  'pconnect' => TRUE,
-  'db_debug' => TRUE,
-  'cache_on' => FALSE,
-  'cachedir' => ""
-);
+$db['eus_for_myemsl'] = $db['default'];
+$db['eus_for_myemsl']['dbprefix'] = 'eus.';
 
 /* End of file database.php */
 /* Location: ./application/config/database.php */

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -67,5 +67,8 @@ $db['default'] = array(
 $db['eus_for_myemsl'] = $db['default'];
 $db['eus_for_myemsl']['dbprefix'] = 'eus.';
 
+$db['website_prefs'] = $db['default'];
+$db['website_prefs']['dbprefix'] = 'website_prefs.';
+
 /* End of file database.php */
 /* Location: ./application/config/database.php */

--- a/application/libraries/EUS.php
+++ b/application/libraries/EUS.php
@@ -21,7 +21,22 @@ class EUS
         define('PROPOSAL_MEMBERS', 'proposal_members');
         define('USERS_TABLE', 'users');
 
-        $this->CI->load->database('eus_for_myemsl');
+        if (!$this->CI->load->database('eus_for_myemsl')) {
+            $this->CI->load->database('eus_for_myemsl');
+            $db_config = array(		
+                'hostname' => 'localhost',
+                'username' => 'eus_access',
+                'password' => 'changeme',
+                'database' => 'EUS',
+                'dbdriver' => 'mysqli',
+                'dbprefix' => '',
+                'pconnect' => true,
+                'db_debug' => true,
+                'cache_on' => false,
+                'cachedir' => '',
+            );		
+            $this->CI->load->database($db_config);		
+        }
     }
 
 

--- a/application/libraries/EUS.php
+++ b/application/libraries/EUS.php
@@ -21,22 +21,7 @@ class EUS
         define('PROPOSAL_MEMBERS', 'proposal_members');
         define('USERS_TABLE', 'users');
 
-        if (!$this->CI->load->database('eus_for_myemsl')) {
-            $myemsl_array = parse_ini_file('/etc/myemsl/general.ini', true);
-            $db_config = array(
-                'hostname' => $myemsl_array['metadata']['host'],
-                'username' => $myemsl_array['metadata']['user'],
-                'password' => $myemsl_array['metadata']['password'],
-                'database' => $myemsl_array['metadata']['database'],
-                'dbdriver' => 'postgre',
-                'dbprefix' => 'eus.',
-                'pconnect' => true,
-                'db_debug' => true,
-                'cache_on' => false,
-                'cachedir' => '',
-            );
-            $this->CI->load->database($db_config);
-        }
+        $this->CI->load->database('eus_for_myemsl');
     }
 
 

--- a/application/libraries/EUS.php
+++ b/application/libraries/EUS.php
@@ -23,7 +23,7 @@ class EUS
 
         if (!$this->CI->load->database('eus_for_myemsl')) {
             $this->CI->load->database('eus_for_myemsl');
-            $db_config = array(		
+            $db_config = array(
                 'hostname' => 'localhost',
                 'username' => 'eus_access',
                 'password' => 'changeme',
@@ -34,8 +34,8 @@ class EUS
                 'db_debug' => true,
                 'cache_on' => false,
                 'cachedir' => '',
-            );		
-            $this->CI->load->database($db_config);		
+            );
+            $this->CI->load->database($db_config);
         }
     }
 


### PR DESCRIPTION
This removes the copy of the database config hash and seeds
everything starting at $db['default']