### PR TITLE
Issue 110 misformatted time stamps

### DIFF
--- a/application/controllers/Status_api.php
+++ b/application/controllers/Status_api.php
@@ -52,7 +52,7 @@ class Status_api extends Baseline_api_controller
         // $this->load->model('Cart_model', 'cart');
         $this->load->helper(
             array(
-                'url', 'html', 'myemsl_api', 'file_info', 'theme'
+                'url', 'html', 'myemsl_api', 'file_info', 'theme', 'time'
             )
         );
 

--- a/application/helpers/item_helper.php
+++ b/application/helpers/item_helper.php
@@ -49,12 +49,10 @@ function build_folder_structure(&$dirs, $path_array, $item_info)
         build_folder_structure($dirs['folders'][$path_array[0]], array_splice($path_array, 1), $item_info);
     } else {
         $size_string = format_bytes($item_info['size']);
-        $m_time = new DateTime($item_info['mtime']);
-        $date_string = $m_time->format('n/j/Y g:ia');
+        $date_string = utc_to_local_time($item_info['mtime'], 'n/j/Y g:ia T');
         $item_id = $item_info['_id'];
         $hashsum = $item_info['hashsum'];
         $url = "{$CI->file_url_base}/files/sha1/{$hashsum}";
-        // $url = base_url()."myemsl/itemauth/{$item_id}";
         $item_info['url'] = $url;
         $item_info_json = json_encode($item_info);
         $fineprint = "[File Size: {$size_string}; Last Modified: {$date_string}]";

--- a/application/views/upload_item_view.html
+++ b/application/views/upload_item_view.html
@@ -9,7 +9,7 @@
 <?php foreach($transaction_data['times'] as $upload_time_string => $transaction_id): ?>
 <?php
       $transaction_info = $transaction_data['transactions'][$transaction_id];
-      $friendly_upload_time = utc_to_local_time($upload_time_string, 'D, M j Y g:ia');
+      $friendly_upload_time = utc_to_local_time($upload_time_string, 'D, M j Y g:ia T');
 ?>
     <fieldset id="fieldset_<?= $transaction_id ?>" class="transaction_container">
         <legend>


### PR DESCRIPTION
This fixes the issue with file modification times being reported in GMT (with no notation as such). Times are now in local time (as defined in the config file), and have the timezone abbreviation appended to them for clarity.