### PR TITLE
Corrected for mismatched owner id's

### DIFF
--- a/application/config/data_release.php
+++ b/application/config/data_release.php
@@ -14,6 +14,8 @@
 defined('BASEPATH') or exit('No direct script access allowed');
 
 $config['drhub_url_base'] = 'https://lampdev02.pnl.gov/drhub/drhub/api';
-$config['drhub_username'] = 'svcDataHub';
-$config['drhub_password'] = 'D@taHubP@ss73';
+// $config['drhub_username'] = 'svcDataHub';
+// $config['drhub_password'] = 'D@taHubP@ss73';
+$config['drhub_username'] = 'svcDataHubAdmin';
+$config['drhub_password'] = 'password';
 $config['drhub_default_repository_name'] = 'EMSL';


### PR DESCRIPTION
Newly created and linked data resources had the uid/name of the service account rather than the user who actually created the data set in the first place. Fixed now

Fixes #220 