### PR TITLE
bump the allowed download size

### DIFF
--- a/application/resources/scripts/myemsl_file_download.js
+++ b/application/resources/scripts/myemsl_file_download.js
@@ -1,4 +1,4 @@
-var max_size = 1024 * 1024 * 1024 * 50; //50 GB (base 2)
+var max_size = 1024 * 1024 * 1024 * 1024 * 5; //5 TB (base 2)
 var friendly_max_size = "";
 var exceed_max_size_allow = false;
 var cart_create_dialog, cart_create_form;


### PR DESCRIPTION
The PNCC data sets are quite large 2TB plus and need to be allowed to download.